### PR TITLE
Removing alexa-rank

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Collection of awesome resources and libraries for the [Amazon Echo](https://en.w
 - [ASK-fortune](https://github.com/miguelmota/ASK-fortune) - "Read a random, hopefully interesting, adage."
 - [gmail-on-alexa](https://github.com/s-maheshbabu/gmail-on-alexa) - "Gmail skill for Amazon Alexa."
 - [alexa-plex](https://github.com/OverloadUT/alexa-plex) - "Alexa (Amazon Echo) app for interacting with a Plex Server and controlling client playback."
-- [alexarank](https://github.com/fcambus/alexarank) - "A simple node package to get Alexa traffic rank for a domain or URL."
 - [trash-talk](https://github.com/JoshMilo/trash-talk) - "100 greatest movie insults of all time to motivate you."
 - [AlexaMakeMeASandwich](https://github.com/timkarnold/AlexaMakeMeASandwich) - "Chrome Extension that turns your Amazon Echo into a Sandwich Artisan."
 - [LIFX-Alexa-Skill](https://github.com/Seechay/LIFX-Alexa-Skill) - "An Alexa Skill created for the Amazon Echo that allows you to control your LIFX Lightbulbs."


### PR DESCRIPTION
alexa-rank is a module for the web traffic data site; it is completely unrelated to the ASK/AVS ecosystem.